### PR TITLE
feat: Improve logo visibility in Google Search

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,8 @@
     <meta name="description" content="A robust, single-file media player supporting local files, external links, subtitles, and extensive subtitle customization.">
     <meta name="keywords" content="robust player, robust media player, rmp, media player, video player, audio player, local player, local media player, local video player with subs, subtitle customizer, VTT, SRT, local media">
     
-    <link rel="icon" href="assets/logo.png" type="image/png">
-    <link rel="icon" type="image/png" sizes="32x32" href="assets/logo.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="assets/logo.png">
-    <link rel="shortcut icon" href="assets/logo.png">
-    
-    <link rel="apple-touch-icon" href="assets/logo.png">
+    <link rel="icon" href="/assets/logo.png" sizes="any" type="image/png">
+    <link rel="apple-touch-icon" href="/assets/logo.png">
     <link rel="apple-touch-icon" sizes="76x76" href="assets/logo.png">
     <link rel="apple-touch-icon" sizes="120x120" href="assets/logo.png">
     <link rel="apple-touch-icon" sizes="152x152" href="assets/logo.png">
@@ -28,6 +24,15 @@
     <meta name="msapplication-TileColor" content="#3b82f6">
     <meta name="theme-color" id="theme-color-meta" content="#3b82f6">
     <script src="https://cdn.tailwindcss.com"></script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "url": "https://robustplayer.vercel.app/",
+      "logo": "https://robustplayer.vercel.app/assets/logo.png"
+    }
+    </script>
     
     <!-- FONT AWESOME FOR ICONS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" xintegrity="sha512-SnH5WK+bZxgPHs44uWIX+LLMDJdQkYmB4J7s8pQ/6T+o6H+P45U+k5+8fJg+C6S6" crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
To ensure the custom logo is displayed in Google Search results, this change implements two key improvements:

1.  **Standardized Favicon Links:** The numerous favicon `<link>` tags in `index.html` have been consolidated into a single, standardized tag with an absolute path (`/assets/logo.png`). An `apple-touch-icon` link with an absolute path is also included for Apple devices.

2.  **Schema.org Markup:** Added `JSON-LD` structured data to the `<head>` of the `index.html` file. This markup explicitly defines the website as an "Organization" and specifies the absolute URL to the logo, following Google's recommended best practices for logo discovery.